### PR TITLE
Handle return value of undefined or null

### DIFF
--- a/src/rpc-common.ts
+++ b/src/rpc-common.ts
@@ -87,7 +87,7 @@ export abstract class RpcCommon implements IRpc {
       try {
         let response: any = func.apply(thisArg, message.params);
         // if response is a promise, delay the response until the promise is fulfilled
-        if (typeof response.then === "function") {
+        if (response && typeof response.then === "function") {
           response = await response;
         }
         this.sendResponse(message.id, response);


### PR DESCRIPTION
If a remote method was called using `invoke()` and that method didn't specify a return value, `undefined` was returned. That caused the promise-check to throw an exception.