### PR TITLE
Set declaration to true for the rpc-browser

### DIFF
--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -6,7 +6,8 @@
 		"lib": ["es6", "dom"],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true
+		"strict": true,
+		"declaration": true
 	},
 	"exclude": ["node_modules", "src/rpc-extension.ts", "src/rpc-extension-ws.ts", "example", "example-ws"]
 }


### PR DESCRIPTION
In order to generate .d.ts file for the rpc-browser, the declaration parameter is set to true.

Fixes #91