### PR TITLE
feat: support cross-plugin invocation via plugin:method syntax

### DIFF
--- a/jest.config.unit.js
+++ b/jest.config.unit.js
@@ -5,5 +5,9 @@ module.exports = {
   moduleFileExtensions: ["ts", "js", "json", "node" ],
   roots: ["<rootDir>/src"],
   preset: "ts-jest",
-  coveragePathIgnorePatterns: ["src/test/.*"]
+  coveragePathIgnorePatterns: ["src/test/.*"],
+  // Map .js imports to .ts source files (browser modules use .js extensions)
+  moduleNameMapper: {
+    "^(\\.\\.?/.*)\\.js$": "$1"
+  }
 };

--- a/src/rpc-browser-ws-multi.ts
+++ b/src/rpc-browser-ws-multi.ts
@@ -6,9 +6,11 @@
  *
  * 1. **Plugin (consumer) namespacing** — Messages include a `plugin` field; only messages
  *    for this plugin are processed
- * 2. **Auto-reconnect** — Automatically reconnects after disconnect
- * 3. **Message queueing** — Messages sent before connection is open are queued
- * 4. **Lifecycle management** — Explicit connect()/disconnect() methods
+ * 2. **Cross-plugin invocation** — Use `"targetPlugin:methodName"` syntax to call methods
+ *    on a different plugin's backend
+ * 3. **Auto-reconnect** — Automatically reconnects after disconnect
+ * 4. **Message queueing** — Messages sent before connection is open are queued
+ * 5. **Lifecycle management** — Explicit connect()/disconnect() methods
  *
  * @example
  * ```ts
@@ -16,7 +18,11 @@
  * rpc.registerMethod({ func: handleNotification, name: 'notify' });
  * rpc.connect();
  *
+ * // Call own backend
  * const data = await rpc.invoke('getData', arg1, arg2);
+ *
+ * // Call another plugin's backend
+ * const file = await rpc.invoke('filesystem:readFile', '/path/to/file');
  * ```
  */
 
@@ -103,6 +109,27 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
   }
 
   /**
+   * Parse a method string that may contain a plugin prefix.
+   *
+   * Supports two forms:
+   * - `"methodName"` — routes to this plugin's backend (uses `this.pluginName`)
+   * - `"targetPlugin:methodName"` — routes to a different plugin's backend
+   *
+   * A colon at position 0 (e.g. `":foo"`) is not treated as a separator;
+   * the entire string is used as the method name with `this.pluginName`.
+   */
+  private parseMethod(method: string): { plugin: string; method: string } {
+    const colonIndex = method.indexOf(":");
+    if (colonIndex > 0) {
+      return {
+        plugin: method.substring(0, colonIndex),
+        method: method.substring(colonIndex + 1),
+      };
+    }
+    return { plugin: this.pluginName, method };
+  }
+
+  /**
    * Open the WebSocket connection.
    * Automatically reconnects on disconnect if autoReconnect is enabled.
    */
@@ -130,18 +157,21 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
       try {
         const message: RpcMultiMessage = JSON.parse(event.data as string);
 
-        // Only handle messages for this plugin
-        if (message.plugin !== this.pluginName) {
-          return;
-        }
-
-        this.logger.debug(`Received: ${JSON.stringify(message)}`);
-
         switch (message.command) {
           case "rpc-request":
+            // Only handle requests addressed to this plugin
+            if (message.plugin !== this.pluginName) {
+              return;
+            }
+            this.logger.debug(`Received request: ${JSON.stringify(message)}`);
             this.handleRequest(message);
             break;
           case "rpc-response":
+            // Match responses by request id (supports cross-plugin responses)
+            if (!this.promiseCallbacks.has(message.id)) {
+              return;
+            }
+            this.logger.debug(`Received response: ${JSON.stringify(message)}`);
             this.handleResponse(message);
             break;
         }
@@ -206,13 +236,19 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
   }
 
   /**
-   * Invoke a method on the backend plugin(consumer) and return the result.
+   * Invoke a method on a backend plugin and return the result.
    *
-   * @param method The method name to invoke on the server side
+   * Supports two calling conventions:
+   * - `invoke("methodName", ...params)` — calls a method on this plugin's own backend
+   * - `invoke("targetPlugin:methodName", ...params)` — calls a method on a different
+   *   plugin's backend (cross-plugin invocation)
+   *
+   * @param method The method name, or `"targetPlugin:methodName"` for cross-plugin calls
    * @param params Parameters to pass
    * @returns A promise that resolves with the result from the backend
    */
   invoke(method: string, ...params: any[]): Promise<any> {
+    const parsed = this.parseMethod(method);
     const id = Math.random();
     const promise = new Promise((resolve, reject) => {
       this.promiseCallbacks.set(id, { resolve, reject });
@@ -229,10 +265,10 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
     }, this.timeout);
 
     const requestObject: RpcMultiMessage = {
-      plugin: this.pluginName,
+      plugin: parsed.plugin,
       command: "rpc-request",
       id: id,
-      method: method,
+      method: parsed.method,
       params: params,
     };
 
@@ -245,6 +281,8 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
   // -------------------------------------------------------------------------
 
   sendRequest(id: number, method: string, params?: any[]): void {
+    const parsed = this.parseMethod(method);
+
     // Set timeout
     setTimeout(() => {
       const promiseCallbacks: IPromiseCallbacks | undefined = this.promiseCallbacks.get(id);
@@ -256,10 +294,10 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
     }, this.timeout);
 
     const requestBody: RpcMultiMessage = {
-      plugin: this.pluginName,
+      plugin: parsed.plugin,
       command: "rpc-request",
       id: id,
-      method: method,
+      method: parsed.method,
       params: params,
     };
 

--- a/src/rpc-server-ws-multi.ts
+++ b/src/rpc-server-ws-multi.ts
@@ -12,6 +12,12 @@
  * Designed for architecture where the core WebSocket handler
  * routes messages to plugin-specific RPC servers based on the `plugin` field.
  *
+ * **Cross-plugin invocation:** The browser-side counterpart (`RpcBrowserWebSocketsMulti`)
+ * supports `"targetPlugin:methodName"` syntax to invoke methods on a different plugin's
+ * backend. On the server side, the core WebSocket router already handles routing the
+ * incoming message to the correct `RpcServerWebSocketsMulti` instance based on the
+ * `plugin` field — no changes are needed here.
+ *
  * @example
  * ```ts
  * const rpc = new RpcServerWebSocketsMulti('my-plugin', logger);

--- a/src/test/rpc-multi.test.ts
+++ b/src/test/rpc-multi.test.ts
@@ -1,0 +1,323 @@
+import { RpcBrowserWebSocketsMulti } from "../rpc-browser-ws-multi";
+import { RpcServerWebSocketsMulti } from "../rpc-server-ws-multi";
+import { RpcMultiMessage } from "../rpc-common";
+import { noopLogger } from "../noop-logger";
+
+// ---------------------------------------------------------------------------
+// WebSocket mock for RpcBrowserWebSocketsMulti
+// ---------------------------------------------------------------------------
+
+type WsListener = (event: { data: string }) => void;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  private listeners: Map<string, Function[]> = new Map();
+  readyState = 1; // OPEN
+
+  /** Messages sent by the RPC client */
+  sent: string[] = [];
+
+  /** Callback injected by the test to handle outgoing messages */
+  onSend?: (data: string) => void;
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+    // Auto-fire "open" on next tick
+    setTimeout(() => this.fireEvent("open", {}), 0);
+  }
+
+  addEventListener(event: string, fn: Function): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, []);
+    }
+    this.listeners.get(event)!.push(fn);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+    this.onSend?.(data);
+  }
+
+  close(): void {
+    this.fireEvent("close", {});
+  }
+
+  /** Simulate receiving a message from the server */
+  simulateMessage(data: string): void {
+    this.fireEvent("message", { data });
+  }
+
+  fireEvent(event: string, payload: any): void {
+    for (const fn of this.listeners.get(event) || []) {
+      fn(payload);
+    }
+  }
+}
+
+// Install mock globally before any test uses it
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  (globalThis as any).WebSocket = MockWebSocket;
+  // Provide window.location for defaultWsUrl()
+  if (typeof window === "undefined") {
+    (globalThis as any).window = {
+      location: { protocol: "http:", host: "localhost:3000" },
+    };
+  }
+});
+
+afterEach(() => {
+  delete (globalThis as any).WebSocket;
+});
+
+// ---------------------------------------------------------------------------
+// Helper: wire a browser client to a server via the mock WebSocket
+// ---------------------------------------------------------------------------
+
+function wireClientToServer(
+  client: RpcBrowserWebSocketsMulti,
+  servers: Map<string, RpcServerWebSocketsMulti>
+): void {
+  // Wait for the MockWebSocket to be created by connect()
+  const checkWs = () => {
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    if (!ws) return;
+
+    const connectionId = "test-conn-1";
+
+    // Client → Server: intercept WS sends and route to the correct server
+    ws.onSend = (data: string) => {
+      const msg: RpcMultiMessage = JSON.parse(data);
+      const server = servers.get(msg.plugin);
+      if (server) {
+        // Register the connection's send function (server → client)
+        server.addConnection(connectionId, (responseData: string) => {
+          ws.simulateMessage(responseData);
+        });
+        server.handleMessage(msg, connectionId);
+      }
+    };
+  };
+
+  // The WebSocket is created synchronously in connect(), so check immediately
+  setTimeout(checkWs, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RpcBrowserWebSocketsMulti — cross-plugin invoke", () => {
+  it("invoke('method') routes to own plugin (backward compat)", (done) => {
+    const server = new RpcServerWebSocketsMulti("my-plugin", noopLogger);
+    server.registerMethod({
+      func: (a: number, b: number) => a + b,
+      name: "sum",
+    });
+
+    const servers = new Map([["my-plugin", server]]);
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+
+    wireClientToServer(client, servers);
+    client.connect();
+
+    // Wait for "open" event (fires on next tick)
+    setTimeout(async () => {
+      const result = await client.invoke("sum", 3, 4);
+      expect(result).toBe(7);
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("invoke('otherPlugin:method') routes to a different plugin", (done) => {
+    const myServer = new RpcServerWebSocketsMulti("my-plugin", noopLogger);
+    const fsServer = new RpcServerWebSocketsMulti("filesystem", noopLogger);
+
+    fsServer.registerMethod({
+      func: (path: string) => `contents of ${path}`,
+      name: "readFile",
+    });
+
+    const servers = new Map([
+      ["my-plugin", myServer],
+      ["filesystem", fsServer],
+    ]);
+
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    wireClientToServer(client, servers);
+    client.connect();
+
+    setTimeout(async () => {
+      const result = await client.invoke("filesystem:readFile", "/foo.txt");
+      expect(result).toBe("contents of /foo.txt");
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("invoke with ':' at position 0 treats entire string as method name", (done) => {
+    const server = new RpcServerWebSocketsMulti("my-plugin", noopLogger);
+    server.registerMethod({
+      func: () => "ok",
+      name: ":weirdName",
+    });
+
+    const servers = new Map([["my-plugin", server]]);
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    wireClientToServer(client, servers);
+    client.connect();
+
+    setTimeout(async () => {
+      const result = await client.invoke(":weirdName");
+      expect(result).toBe("ok");
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("cross-plugin response is not dropped by message filter", (done) => {
+    // This test verifies the bug fix: previously, responses from cross-plugin
+    // calls were dropped because message.plugin !== this.pluginName.
+    const fsServer = new RpcServerWebSocketsMulti("filesystem", noopLogger);
+    fsServer.registerMethod({
+      func: () => 42,
+      name: "getSize",
+    });
+
+    const servers = new Map([["filesystem", fsServer]]);
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    wireClientToServer(client, servers);
+    client.connect();
+
+    setTimeout(async () => {
+      // The response will have plugin: "filesystem" but client is "my-plugin"
+      const result = await client.invoke("filesystem:getSize");
+      expect(result).toBe(42);
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("requests from other plugins are not processed", (done) => {
+    const handler = jest.fn(() => "should not be called");
+
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    client.registerMethod({ func: handler, name: "secret" });
+    client.connect();
+
+    setTimeout(() => {
+      const ws = MockWebSocket.instances[0];
+
+      // Simulate a request from a different plugin
+      ws.simulateMessage(JSON.stringify({
+        plugin: "other-plugin",
+        command: "rpc-request",
+        id: 0.12345,
+        method: "secret",
+        params: [],
+      }));
+
+      // Give time for any potential handling
+      setTimeout(() => {
+        expect(handler).not.toHaveBeenCalled();
+        client.disconnect();
+        done();
+      }, 10);
+    }, 10);
+  });
+
+  it("requests addressed to own plugin are still processed", (done) => {
+    const handler = jest.fn(() => "hello");
+
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    client.registerMethod({ func: handler, name: "greet" });
+    client.connect();
+
+    setTimeout(() => {
+      const ws = MockWebSocket.instances[0];
+
+      ws.simulateMessage(JSON.stringify({
+        plugin: "my-plugin",
+        command: "rpc-request",
+        id: 0.99,
+        method: "greet",
+        params: [],
+      }));
+
+      setTimeout(() => {
+        expect(handler).toHaveBeenCalled();
+        client.disconnect();
+        done();
+      }, 10);
+    }, 10);
+  });
+
+  it("sendRequest also parses plugin:method", (done) => {
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    client.connect();
+
+    setTimeout(() => {
+      const ws = MockWebSocket.instances[0];
+
+      // Call sendRequest directly (used by listRemoteMethods / base class)
+      (client as any).sendRequest(0.5, "other:getData", ["arg1"]);
+
+      expect(ws.sent.length).toBe(1);
+      const msg = JSON.parse(ws.sent[0]);
+      expect(msg.plugin).toBe("other");
+      expect(msg.method).toBe("getData");
+      expect(msg.params).toEqual(["arg1"]);
+
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("async methods work with cross-plugin invoke", (done) => {
+    const fsServer = new RpcServerWebSocketsMulti("filesystem", noopLogger);
+    fsServer.registerMethod({
+      func: async (path: string) => {
+        return `async contents of ${path}`;
+      },
+      name: "readFileAsync",
+    });
+
+    const servers = new Map([["filesystem", fsServer]]);
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    wireClientToServer(client, servers);
+    client.connect();
+
+    setTimeout(async () => {
+      const result = await client.invoke("filesystem:readFileAsync", "/bar.txt");
+      expect(result).toBe("async contents of /bar.txt");
+      client.disconnect();
+      done();
+    }, 10);
+  });
+
+  it("error from cross-plugin invoke is properly rejected", (done) => {
+    const fsServer = new RpcServerWebSocketsMulti("filesystem", noopLogger);
+    fsServer.registerMethod({
+      func: () => { throw new Error("file not found"); },
+      name: "readFile",
+    });
+
+    const servers = new Map([["filesystem", fsServer]]);
+    const client = new RpcBrowserWebSocketsMulti("my-plugin", "ws://localhost/ws", noopLogger);
+    wireClientToServer(client, servers);
+    client.connect();
+
+    setTimeout(async () => {
+      try {
+        await client.invoke("filesystem:readFile", "/missing.txt");
+        done.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBe("file not found");
+        client.disconnect();
+        done();
+      }
+    }, 10);
+  });
+});

--- a/tsconfig.ext.json
+++ b/tsconfig.ext.json
@@ -9,5 +9,5 @@
 		"strict": true,
 		"declaration": true
 	},
-	"exclude": ["node_modules", "src/rpc-browser.ts", "src/rpc-browser-ws.ts", "src/rpc-browser-ws-multi.ts", "example", "example-ws"]
+	"exclude": ["node_modules", "src/rpc-browser.ts", "src/rpc-browser-ws.ts", "src/rpc-browser-ws-multi.ts", "src/test", "example", "example-ws"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,5 +9,5 @@
 		"strict": true
 	},
 	"exclude": ["node_modules", "example", "example-ws"],
-	"include": ["src/rpc-common.ts", "src/test/*.ts"]
+	"include": ["src/rpc-common.ts", "src/noop-logger.ts", "src/rpc-server-ws-multi.ts", "src/test/rpc-mock.ts", "src/test/rpc.test.ts", "src/test/logger.spec.ts"]
 }


### PR DESCRIPTION
Add parseMethod() to RpcBrowserWebSocketsMulti that splits a "targetPlugin:methodName" string so invoke() can route requests to a different plugin's backend over the shared WebSocket.

Fix response filtering: match responses by request id instead of plugin name, so cross-plugin responses are no longer silently dropped.

Includes 8 new unit tests covering cross-plugin invoke, backward compatibility, response filtering, and edge cases.