### PR TITLE
ci: modernize workflows and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,18 +10,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-    - dependency-name: actions/checkout
 
   # Maintain dependencies for npm
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
-    ignore:
-    - dependency-name: "ws"
-    - dependency-name: "@types/node"
-    - dependency-name: "@types/vscode"
-    - dependency-name: "@types/ws"
-    - dependency-name: "typescript"
-      versions: ["5.x"]
+
+  - package-ecosystem: npm
+    directory: "/example"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/example-ws"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [24.x]
+        node_version: [22.x, 24.x, 26.x]
       # https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,13 @@ jobs:
       fail-fast: false
 
     steps:
-      # using `v1` because of: https://github.com/actions/checkout/issues/246
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [20.x, 22.x, 24.x]
+        node_version: [24.x]
       # https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails
       fail-fast: false
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,7 +14,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      # using `v1` because of: https://github.com/actions/checkout/issues/246
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci

--- a/example-ws/package-lock.json
+++ b/example-ws/package-lock.json
@@ -18,6 +18,9 @@
         "eslint": "^8.56.0",
         "rimraf": "^5.0.5",
         "typescript": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/example-ws/package.json
+++ b/example-ws/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "watch": "tsc -w -p .",
     "prep": "cd .. && npm run compile && copyfiles -u 1 ./out.browser/*.js ./example-ws/src/static/rpc/ && copyfiles -u 1 ./src/rpc-common.ts ./example-ws/src/rpc/ && copyfiles -u 1 ./src/rpc-extension-ws.ts ./example-ws/src/rpc/",

--- a/example-ws/package.json
+++ b/example-ws/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "scripts": {
     "watch": "tsc -w -p .",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -22,6 +22,7 @@
 				"vscode-test": "^1.6.1"
 			},
 			"engines": {
+				"node": ">=24",
 				"vscode": "^1.38.0"
 			}
 		},

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
 	"description": "",
 	"version": "0.0.1",
 	"engines": {
+		"node": ">=24",
 		"vscode": "^1.38.0"
 	},
 	"categories": [

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
 	"description": "",
 	"version": "0.0.1",
 	"engines": {
-		"node": ">=24",
+		"node": ">=22",
 		"vscode": "^1.38.0"
 	},
 	"categories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "rimraf": "^5.0.5",
         "ts-jest": "^29.1.2",
         "typescript": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Ido Perez",
   "publisher": "SAP",
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "scripts": {
     "ci": "npm run compile && npm run lint && npm run test && npm pack",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "license": "Apache 2.0",
   "author": "Ido Perez",
   "publisher": "SAP",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "ci": "npm run compile && npm run lint && npm run test && npm pack",
     "clean": "rimraf ./out.*",


### PR DESCRIPTION
Split from PR #547. Scope: GitHub Actions checkout updates, npm ci in CI/release, Dependabot configuration for root and examples, and Node.js 24 as the documented repo/runtime baseline via package engines. CI now runs only on Node 24.x.