### PR TITLE
fix: improve RPC request timeouts

### DIFF
--- a/example-ws/src/rpc/rpc-common.ts
+++ b/example-ws/src/rpc/rpc-common.ts
@@ -53,6 +53,13 @@ export abstract class RpcCommon implements IRpc {
     return this.invoke("listLocalMethods");
   }
 
+  protected scheduleResponseTimeout(callback: () => void): void {
+    const timer = setTimeout(callback, this.timeout);
+    if (typeof timer === "object" && typeof timer.unref === "function") {
+      timer.unref();
+    }
+  }
+
   invoke(method: string, ...params: any[]): Promise<any> {
   // TODO: change to something more unique (or check to see if id doesn't alreday exist in this.promiseCallbacks)
     const id = Math.random();

--- a/example-ws/src/rpc/rpc-extension-ws.ts
+++ b/example-ws/src/rpc/rpc-extension-ws.ts
@@ -23,13 +23,13 @@ export class RpcExtensionWebSockets extends RpcCommon {
 
   sendRequest(id: number, method: string, params?: any[]) {
     // consider cancelling the timer if the promise if fulfilled before timeout is reached
-    setTimeout(() => {
+    this.scheduleResponseTimeout(() => {
       const promiseCallbacks: IPromiseCallbacks | undefined = this.promiseCallbacks.get(id);
       if (promiseCallbacks) {
         promiseCallbacks.reject("Request timed out");
         this.promiseCallbacks.delete(id);
       }
-    }, this.timeout);
+    });
 
     const requestObject: any = {
       command: "rpc-request",

--- a/src/rpc-browser-ws-multi.ts
+++ b/src/rpc-browser-ws-multi.ts
@@ -249,7 +249,7 @@ export class RpcBrowserWebSocketsMulti extends RpcCommon {
    */
   invoke(method: string, ...params: any[]): Promise<any> {
     const parsed = this.parseMethod(method);
-    const id = Math.random();
+    const id = ++this.nextId;
     const promise = new Promise((resolve, reject) => {
       this.promiseCallbacks.set(id, { resolve, reject });
     });

--- a/src/rpc-browser-ws.ts
+++ b/src/rpc-browser-ws.ts
@@ -3,7 +3,7 @@
 
 import { RpcCommon, IPromiseCallbacks } from "./rpc-common.js";
 import { IChildLogger } from "@vscode-logging/types";
-import { noopLogger } from "./noop-logger";
+import { noopLogger } from "./noop-logger.js";
 
 export class RpcBrowserWebSockets extends RpcCommon {
   private static readonly className = "RpcBrowserWebSockets";

--- a/src/rpc-common.ts
+++ b/src/rpc-common.ts
@@ -48,11 +48,12 @@ export interface IMethod {
 export abstract class RpcCommon implements IRpc {
   abstract sendRequest(id: number, method: string, params?: any[]): void;
   abstract sendResponse(id: number, response: any, success?: boolean): void;
-  protected promiseCallbacks: Map<number, IPromiseCallbacks>; // promise resolve and reject callbacks that are called when returning from remote
+  protected promiseCallbacks: Map<number, IPromiseCallbacks>;
   protected methods: Map<string, IMethod>;
   private readonly baseLogger: IChildLogger;
   // TODO: timeouts do not make sense for user interactions. consider not using timeouts by default
   protected timeout: number = 3600000; // timeout for response from remote in milliseconds
+  protected nextId: number = 0;
 
   constructor(logger: IChildLogger) {
     this.promiseCallbacks = new Map();
@@ -89,8 +90,7 @@ export abstract class RpcCommon implements IRpc {
   }
 
   invoke(method: string, ...params: any[]): Promise<any> {
-  // TODO: change to something more unique (or check to see if id doesn't already exist in this.promiseCallbacks)
-    const id = Math.random();
+    const id = ++this.nextId;
     const promise = new Promise((resolve, reject) => {
       this.promiseCallbacks.set(id, { resolve: resolve, reject: reject });
     });

--- a/src/test/logger.spec.ts
+++ b/src/test/logger.spec.ts
@@ -29,12 +29,12 @@ describe("Logger tests", () => {
     expect(trace).toHaveBeenCalledTimes(2);
     expect(trace).toHaveBeenCalledWith(
       expect.stringMatching(
-        /handleRequest: processing request id: \d\.\d+ method: sum parameters: \[1,2\]/
+        /handleRequest: processing request id: \d+\.?\d* method: sum parameters: \[1,2\]/
       )
     );
     expect(trace).toHaveBeenCalledWith(
       expect.stringMatching(
-        /handleResponse: processing response for id: \d\.\d+ message success flag is: true/
+        /handleResponse: processing response for id: \d+\.?\d* message success flag is: true/
       )
     );
   });
@@ -81,19 +81,19 @@ describe("Logger tests", () => {
     
     expect(trace).toHaveBeenCalledWith(
       expect.stringMatching(
-        /handleRequest: processing request id: \d\.\d+ method: bad parameters: \[1,0\]/
+        /handleRequest: processing request id: \d+\.?\d* method: bad parameters: \[1,0\]/
       )
     );
 
     expect(trace).toHaveBeenCalledWith(
       expect.stringMatching(
-        /handleResponse: processing response for id: \d\.\d+ message success flag is: false/
+        /handleResponse: processing response for id: \d+\.?\d* message success flag is: false/
       )
     );
 
-    expect(error).toHaveBeenCalledWith(expect.stringMatching(/handleRequest: Failed processing request rpc-request id: \d\.\d+/), {"error": "bad parameter type"});
+    expect(error).toHaveBeenCalledWith(expect.stringMatching(/handleRequest: Failed processing request rpc-request id: \d+\.?\d*/), {"error": "bad parameter type"});
 
-    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/handleResponse: Message id \d\.\d+ rejected, response: bad parameter type/));
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/handleResponse: Message id \d+\.?\d* rejected, response: bad parameter type/));
 
   });
 });


### PR DESCRIPTION
Split from PR #547. Stacked on PR #551. Scope: monotonic request IDs, response timeout scheduling via unref-capable helper, and related test updates. Validation: npm run compile, npm run lint, npm test, npm audit, plus example-ws compile/lint/audit.